### PR TITLE
Add numpy sorting function specifications to benchmark

### DIFF
--- a/lean-vc/benchmarks/numpy_specs/one_thm/NpArgsort-spec.lean
+++ b/lean-vc/benchmarks/numpy_specs/one_thm/NpArgsort-spec.lean
@@ -1,0 +1,11 @@
+namespace NpArgsort
+
+def argsort {n : Nat} (a : Vector Float n) : Vector (Fin n) n := sorry
+
+theorem argsort_spec {n : Nat} (a : Vector Float n) :
+  (argsort a).toList.length = n ∧
+  (∀ i j : Fin n, i < j → a[(argsort a)[i]] ≤ a[(argsort a)[j]]) ∧
+  (∀ i : Fin n, ∃ j : Fin n, (argsort a)[j] = i) :=
+sorry
+
+end NpArgsort

--- a/lean-vc/benchmarks/numpy_specs/one_thm/NpSort-spec.lean
+++ b/lean-vc/benchmarks/numpy_specs/one_thm/NpSort-spec.lean
@@ -1,0 +1,11 @@
+namespace NpSort
+
+def sort {n : Nat} (a : Vector Float n) : Vector Float n := sorry
+
+theorem sort_spec {n : Nat} (a : Vector Float n) :
+  (sort a).toList.length = n ∧
+  (∀ i j : Fin n, i < j → (sort a)[i] ≤ (sort a)[j]) ∧
+  (∀ x : Float, (sort a).toList.count x = a.toList.count x) :=
+sorry
+
+end NpSort

--- a/lean-vc/benchmarks/numpy_specs/sep_thm/NpArgsort.lean
+++ b/lean-vc/benchmarks/numpy_specs/sep_thm/NpArgsort.lean
@@ -1,0 +1,24 @@
+/-
+# NumPy Argsort Specification
+
+Returns the indices that would sort an array
+-/
+
+namespace DafnySpecs.NpArgsort
+
+/-- Returns the indices that would sort an array -/
+def argsort {n : Nat} (a : Vector Float n) : Vector (Fin n) n := sorry
+
+/-- Specification: The result has the same length as input -/
+theorem argsort_length {n : Nat} (a : Vector Float n) :
+  (argsort a).toList.length = n := sorry
+
+/-- Specification: Using the returned indices produces a sorted array -/
+theorem argsort_sorts {n : Nat} (a : Vector Float n) :
+  ∀ i j : Fin n, i < j → a[(argsort a)[i]] ≤ a[(argsort a)[j]] := sorry
+
+/-- Specification: The result is a permutation of indices -/
+theorem argsort_is_permutation {n : Nat} (a : Vector Float n) :
+  ∀ i : Fin n, ∃ j : Fin n, (argsort a)[j] = i := sorry
+
+end DafnySpecs.NpArgsort

--- a/lean-vc/benchmarks/numpy_specs/sep_thm/NpSort.lean
+++ b/lean-vc/benchmarks/numpy_specs/sep_thm/NpSort.lean
@@ -1,0 +1,24 @@
+/-
+# NumPy Sort Specification
+
+Return a sorted copy of an array
+-/
+
+namespace DafnySpecs.NpSort
+
+/-- Return a sorted copy of an array -/
+def sort {n : Nat} (a : Vector Float n) : Vector Float n := sorry
+
+/-- Specification: The result has the same length as input -/
+theorem sort_length {n : Nat} (a : Vector Float n) :
+  (sort a).toList.length = n := sorry
+
+/-- Specification: The result is sorted in ascending order -/
+theorem sort_is_sorted {n : Nat} (a : Vector Float n) :
+  ∀ i j : Fin n, i < j → (sort a)[i] ≤ (sort a)[j] := sorry
+
+/-- Specification: The result is a permutation of the input -/
+theorem sort_is_permutation {n : Nat} (a : Vector Float n) :
+  ∀ x : Float, (sort a).toList.count x = a.toList.count x := sorry
+
+end DafnySpecs.NpSort


### PR DESCRIPTION
## Summary
- Add specifications for numpy sorting functions from NumpySpec PR #87
- Implement both `numpy.sort` and `numpy.argsort` specifications
- Follow existing benchmark patterns with `one_thm` and `sep_thm` versions

## Changes
- `one_thm/NpSort-spec.lean`: Single theorem specification for numpy.sort
- `one_thm/NpArgsort-spec.lean`: Single theorem specification for numpy.argsort  
- `sep_thm/NpSort.lean`: Separated theorems for sort (length, ordering, permutation)
- `sep_thm/NpArgsort.lean`: Separated theorems for argsort (length, sorting indices, permutation)

All implementations use `Vector` types and are marked with `sorry` as placeholders, consistent with the benchmark structure.

## Test plan
- [ ] Verify files compile with Lean
- [ ] Ensure consistency with existing benchmark patterns
- [ ] Check specifications match numpy behavior

🤖 Generated with [Claude Code](https://claude.ai/code)