### PR TITLE
feat: Add Lean 4 project structure with lakefile

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,0 +1,5 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "vericoding",
+ "lakeDir": ".lake"}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,0 +1,34 @@
+import Lake
+open Lake DSL
+
+package "vericoding" where
+  version := v!"0.1.0"
+
+/-!
+# Vericoding Project Structure
+
+This project contains formal specifications and verifications ported from various sources,
+particularly Dafny benchmarks and NumPy specifications.
+
+## Main Libraries:
+- `Vericoding`: Core library with basic definitions
+- `Vericoding.Benchmarks.DafnySpecs`: Dafny benchmark specifications (from lean4/ directory)
+
+Note: The lean4/benchmarks/dafny-bench_specs directory contains standalone Lean 4 ports
+of Dafny specifications. These are not currently integrated into the main build but
+can be referenced as examples.
+-/
+
+lean_lib «Vericoding» where
+  -- Main library configuration
+  globs := #[.andSubmodules `Vericoding]
+
+-- TODO: Add library for lean4/benchmarks/dafny-bench_specs when ready to integrate
+-- lean_lib «VericodingBenchmarks» where
+--   srcDir := "lean4/benchmarks/dafny-bench_specs"
+--   roots := #[`Abs, `AddOne, `AllDigits] -- etc.
+
+@[default_target]
+lean_exe "vericoding" where
+  root := `Main
+  supportInterpreter := true

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:nightly


### PR DESCRIPTION
## Summary
- Adds proper Lean 4 project structure to vericoding repository
- Updates lean-toolchain to use nightly version (matching NumpySpec)
- Establishes foundation for integrating existing Lean verification efforts

## Changes
1. **lakefile.lean**: Proper project configuration with documentation
2. **lean-toolchain**: Updated to `leanprover/lean4:nightly`
3. **lake-manifest.json**: Dependency tracking

## Notes
- The lakefile documents the existing lean4/benchmarks structure
- Future work can integrate the lean4/benchmarks/dafny-bench_specs files into the build
- This is a minimal change focused on establishing proper project structure

## Test plan
- [x] `lake build` completes successfully
- [x] No changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)