### PR TITLE
Improve W&B logging

### DIFF
--- a/src/spec_to_code.py
+++ b/src/spec_to_code.py
@@ -7,8 +7,11 @@ generates implementations using various LLM APIs, and iteratively fixes verifica
 """
 
 import argparse
+import json
 import os
+import platform
 import shutil
+import subprocess
 import sys
 import time
 from datetime import datetime
@@ -33,6 +36,8 @@ from vericoding.utils import (
     generate_summary,
     generate_csv_results,
     generate_subfolder_analysis_csv,
+    get_git_remote_url,
+    get_current_branch,
 )
 
 # Initialize environment loading
@@ -265,6 +270,279 @@ def setup_configuration(args) -> ProcessingConfig:
     return config
 
 
+def get_tool_version(config: ProcessingConfig) -> str:
+    """Get the version of the language tool being used."""
+    try:
+        tool_path = get_tool_path(config)
+        if config.language == "verus":
+            result = subprocess.run([tool_path, "--version"], capture_output=True, text=True, timeout=10)
+        elif config.language == "lean":
+            result = subprocess.run([tool_path, "--version"], capture_output=True, text=True, timeout=10)
+        elif config.language == "dafny":
+            result = subprocess.run([tool_path, "/version"], capture_output=True, text=True, timeout=10)
+        else:
+            return f"Unknown tool version for {config.language}"
+        
+        if result.returncode == 0:
+            return result.stdout.strip()
+        else:
+            return f"Failed to get version: {result.stderr.strip()}"
+    except Exception as e:
+        return f"Error getting version: {str(e)}"
+
+
+def get_experiment_metadata(config: ProcessingConfig, args) -> dict:
+    """Collect comprehensive metadata for the experiment."""
+    # Get git information
+    git_url = get_git_remote_url()
+    git_branch = get_current_branch()
+    
+    # Get git commit hash
+    git_commit = None
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"], 
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0:
+            git_commit = result.stdout.strip()
+    except Exception:
+        pass
+    
+    # Get hostname
+    hostname = platform.node()
+    
+    # Get tool version
+    tool_version = get_tool_version(config)
+    
+    # Determine input type based on directory contents
+    input_type = determine_input_type(config.files_dir)
+    
+    return {
+        # Basic experiment info
+        "language": config.language,
+        "max_iterations": config.max_iterations,
+        "llm_provider": config.llm_provider,
+        "llm_model": config.llm_model or f"{config.llm_provider}-default",
+        "strict_spec_verification": config.strict_spec_verification,
+        "max_workers": config.max_workers,
+        
+        # File and benchmark info  
+        "files_dir": config.files_dir,
+        "input_type": input_type,
+        "benchmark_files": len(find_spec_files(config)),
+        
+        # Tool versions and environment
+        "tool_version": tool_version,
+        "python_version": platform.python_version(),
+        "platform": platform.system(),
+        "platform_version": platform.release(),
+        "hostname": hostname,
+        
+        # Git information
+        "git_url": git_url,
+        "git_branch": git_branch, 
+        "git_commit": git_commit,
+        
+        # Run configuration
+        "api_rate_limit_delay": config.api_rate_limit_delay,
+        "debug_mode": config.debug_mode,
+        "timestamp": datetime.now().isoformat(),
+        
+        # Command line arguments (for reproducibility)
+        "args": vars(args),
+    }
+
+
+def determine_input_type(files_dir: str) -> str:
+    """Determine the input type based on directory contents or name."""
+    files_dir_name = Path(files_dir).name.lower()
+    
+    if "spec" in files_dir_name:
+        return "spec"
+    elif "vibe" in files_dir_name:
+        return "vibe"
+    else:
+        # Try to detect from file contents or structure
+        spec_keywords = ["requires", "ensures", "invariant", "precondition", "postcondition"]
+        try:
+            # Sample a few files to detect type
+            # Look for files in the directory to sample\n            files_path = Path(files_dir)\n            sample_files = []\n            if files_path.exists():\n                for ext in [\"*.dfy\", \"*.rs\", \"*.lean\"]:\n                    sample_files.extend(list(files_path.rglob(ext))[:2])
+            if spec_files:
+                sample_file = spec_files[0] if len(spec_files) == 1 else spec_files[:min(3, len(spec_files))]
+                for file_path in (sample_file if isinstance(sample_file, list) else [sample_file]):
+                    try:
+                        with open(file_path, 'r') as f:
+                            content = f.read().lower()
+                            if any(keyword in content for keyword in spec_keywords):
+                                return "spec"
+                    except Exception:
+                        continue
+        except Exception:
+            pass
+        
+        return "both"  # Default fallback
+
+
+def log_experiment_results_to_wandb(
+    config: ProcessingConfig, 
+    results: list, 
+    processing_time: float, 
+    success_percentage: float,
+    args
+) -> None:
+    """Log comprehensive experiment results to wandb."""
+    successful = [r for r in results if r.success]
+    failed = [r for r in results if not r.success and not r.has_bypass]
+    bypassed = [r for r in results if r.has_bypass]
+    
+    # Log final summary metrics with better organization
+    summary_metrics = {
+        # Core results
+        "results/total_files": len(results),
+        "results/successful_files": len(successful), 
+        "results/failed_files": len(failed),
+        "results/bypassed_files": len(bypassed),
+        "results/success_rate_percent": success_percentage,
+        
+        # Timing information
+        "performance/duration_seconds": processing_time,
+        "performance/avg_time_per_file": processing_time / len(results) if results else 0,
+        "performance/throughput_files_per_minute": (len(results) / processing_time) * 60 if processing_time > 0 else 0,
+        
+        # Resource usage
+        "resources/parallel_workers": config.max_workers,
+        "resources/api_rate_limit_delay": config.api_rate_limit_delay,
+    }
+    
+    for key, value in summary_metrics.items():
+        wandb.run.summary[key] = value
+    
+    # Create results table for detailed file-by-file analysis
+    results_table = wandb.Table(columns=[
+        "file_name", "subfolder", "success", "output_file", "error_message",
+        "has_bypass", "file_path"
+    ])
+    
+    for result in results:
+        file_path = Path(result.file)
+        subfolder = file_path.parts[0] if len(file_path.parts) > 1 else "root"
+        output_name = Path(result.output).name if result.output else ""
+        error_preview = (result.error[:200] + "...") if result.error and len(result.error) > 200 else (result.error or "")
+        
+        results_table.add_data(
+            file_path.name,
+            subfolder, 
+            result.success,
+            output_name,
+            error_preview,
+            result.has_bypass,
+            str(result.file)
+        )
+    
+    wandb.log({"detailed_results": results_table})
+    
+    # Upload comprehensive artifacts with better organization
+    print("\\n📤 Uploading experiment artifacts to wandb...")
+    
+    # 1. Generated code artifact
+    code_artifact = wandb.Artifact(
+        name=f"generated_code_{config.language}",
+        type="generated-code",
+        description=f"Generated {config.language} code from specifications",
+        metadata={
+            "language": config.language,
+            "success_rate": success_percentage,
+            "total_files": len(results),
+            "llm_model": config.llm_model or f"{config.llm_provider}-default",
+        }
+    )
+    
+    # 2. Debug files artifact (if debug mode enabled)
+    debug_artifact = None
+    if config.debug_mode:
+        debug_artifact = wandb.Artifact(
+            name=f"debug_files_{config.language}",
+            type="debug-files", 
+            description=f"Debug and intermediate files from {config.language} processing",
+            metadata={
+                "language": config.language,
+                "debug_mode": True,
+                "iterations": config.max_iterations,
+            }
+        )
+    
+    # 3. Summary and analysis artifact
+    summary_artifact = wandb.Artifact(
+        name=f"analysis_{config.language}",
+        type="analysis",
+        description=f"Summary reports and CSV analysis for {config.language} experiment",
+        metadata={
+            "language": config.language,
+            "total_files": len(results),
+            "success_rate": success_percentage,
+        }
+    )
+    
+    # Add files to artifacts
+    output_path = Path(config.output_dir)
+    if output_path.exists():
+        for file_path in output_path.rglob("*"):
+            if file_path.is_file():
+                relative_path = file_path.relative_to(output_path)
+                
+                # Categorize files into appropriate artifacts
+                if file_path.suffix in ['.dfy', '.rs', '.lean'] and not any(keyword in file_path.name for keyword in ['iter_', 'debug']):
+                    # Final implementation files go to code artifact
+                    code_artifact.add_file(str(file_path), name=str(relative_path))
+                elif config.debug_mode and ('debug' in str(relative_path) or 'iter_' in file_path.name):
+                    # Debug/intermediate files go to debug artifact
+                    if debug_artifact:
+                        debug_artifact.add_file(str(file_path), name=str(relative_path))
+                elif file_path.suffix in ['.txt', '.csv']:
+                    # Summary and analysis files go to analysis artifact
+                    summary_artifact.add_file(str(file_path), name=str(relative_path))
+                else:
+                    # Fallback to code artifact for other files
+                    code_artifact.add_file(str(file_path), name=str(relative_path))
+    
+    # Log all artifacts
+    wandb.log_artifact(code_artifact)
+    print(f"✅ Generated code uploaded to wandb artifact: generated_code_{config.language}")
+    
+    if debug_artifact and config.debug_mode:
+        wandb.log_artifact(debug_artifact)
+        print(f"✅ Debug files uploaded to wandb artifact: debug_files_{config.language}")
+    
+    wandb.log_artifact(summary_artifact) 
+    print(f"✅ Analysis files uploaded to wandb artifact: analysis_{config.language}")
+    
+    # Store key files directly in wandb.summary for easy access
+    if output_path.exists():
+        summary_file = output_path / "summary.txt"
+        if summary_file.exists():
+            try:
+                with open(summary_file, 'r') as f:
+                    wandb.run.summary["experiment_summary"] = f.read()
+            except Exception as e:
+                print(f"Warning: Could not read summary file: {e}")
+        
+        csv_file = output_path / "results.csv"
+        if csv_file.exists():
+            wandb.run.summary["results_csv_path"] = str(csv_file)
+    
+    # Delete local files if requested
+    if args.delete_after_upload:
+        try:
+            shutil.rmtree(output_path)
+            print(f"🗑️ Local files deleted from {output_path}")
+        except Exception as e:
+            print(f"⚠️ Error deleting local files: {e}")
+    
+    # Finish wandb run
+    wandb.finish()
+
+
 def main():
     """Main entry point for the specification-to-code processing."""
     # Parse command-line arguments first
@@ -279,25 +557,19 @@ def main():
         try:
             # Initialize wandb run
             run_name = f"vericoding_{config.language}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-            wandb_config = {
-                "language": config.language,
-                "max_iterations": config.max_iterations,
-                "llm_provider": config.llm_provider,
-                "llm_model": config.llm_model,
-                "strict_spec_verification": config.strict_spec_verification,
-                "max_workers": config.max_workers,
-                "files_dir": config.files_dir,
-            }
+            
+            # Get comprehensive metadata
+            experiment_metadata = get_experiment_metadata(config, args)
             
             wandb_run = wandb.init(
                 project=os.getenv("WANDB_PROJECT", "vericoding"),
                 entity=os.getenv("WANDB_ENTITY"),
                 name=run_name,
-                tags=[config.language, config.llm_provider],
+                tags=[config.language, config.llm_provider, "spec-to-code"],
                 mode=os.getenv("WANDB_MODE", "online")
             )
-            # Update config with allow_val_change to avoid errors when keys already exist
-            wandb.config.update(wandb_config, allow_val_change=True)
+            # Update config with comprehensive metadata
+            wandb.config.update(experiment_metadata, allow_val_change=True)
             print(f"✅ Weights & Biases tracking enabled: {run_name}")
             if wandb_run:
                 print(f"   View at: {wandb_run.url}")
@@ -434,52 +706,21 @@ def main():
     successful = [r for r in results if r.success]
     failed = [r for r in results if not r.success and not r.has_bypass]
     bypassed = [r for r in results if r.has_bypass]
+    success_percentage = len(successful) / len(results) * 100 if results else 0
     
     print(
-        f"\n🎉 Processing completed: {len(successful)}/{len(results)} files successful ({len(successful) / len(results) * 100:.1f}%)"
+        f"\n🎉 Processing completed: {len(successful)}/{len(results)} files successful ({success_percentage:.1f}%)"
     )
     print(
         f"⚡ Parallel processing with {config.max_workers} workers completed in {processing_time:.2f}s"
     )
     
-    # Log experiment summary to wandb (if enabled)
+    # Log comprehensive experiment summary to wandb (if enabled)
     if wandb_run:
         try:
-            # Log final summary metrics
-            wandb.run.summary["total_files"] = len(results)
-            wandb.run.summary["successful_files"] = len(successful)
-            wandb.run.summary["failed_files"] = len(failed)
-            wandb.run.summary["bypassed_files"] = len(bypassed)
-            wandb.run.summary["success_rate"] = len(successful) / len(results) if results else 0
-            wandb.run.summary["duration_seconds"] = processing_time
-            
-            # Upload generated files as artifacts
-            print("\n📤 Uploading generated files to wandb...")
-            artifact = wandb.Artifact(
-                name=f"generated_code_{config.language}",
-                type="code",
-                description=f"Generated {config.language} code from specifications"
+            log_experiment_results_to_wandb(
+                config, results, processing_time, success_percentage, args
             )
-            
-            # Add the output directory to the artifact
-            output_path = Path(config.output_dir)
-            if output_path.exists():
-                artifact.add_dir(str(output_path))
-                wandb.log_artifact(artifact)
-                print(f"✅ Files uploaded to wandb artifact: generated_code_{config.language}")
-                
-                # Delete local files if requested
-                if args.delete_after_upload:
-                    try:
-                        shutil.rmtree(output_path)
-                        print(f"🗑️  Local files deleted from {output_path}")
-                    except Exception as e:
-                        print(f"⚠️  Error deleting local files: {e}")
-            else:
-                print(f"⚠️  Output directory not found: {output_path}")
-            
-            # Finish wandb run
-            wandb.finish()
             print(f"\n✅ Wandb run completed: {wandb_run.url}")
         except Exception as e:
             print(f"⚠️  Error logging to wandb: {e}")

--- a/src/spec_to_code.py
+++ b/src/spec_to_code.py
@@ -445,9 +445,12 @@ def log_experiment_results_to_wandb(
     # Upload comprehensive artifacts with better organization
     print("\\n📤 Uploading experiment artifacts to wandb...")
     
+    # Create unique artifact names using run timestamp
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    
     # 1. Generated code artifact
     code_artifact = wandb.Artifact(
-        name=f"generated_code_{config.language}",
+        name=f"generated_code_{config.language}_{timestamp}",
         type="generated-code",
         description=f"Generated {config.language} code from specifications",
         metadata={
@@ -455,6 +458,7 @@ def log_experiment_results_to_wandb(
             "success_rate": success_percentage,
             "total_files": len(results),
             "llm_model": config.llm_model or f"{config.llm_provider}-default",
+            "timestamp": timestamp,
         }
     )
     
@@ -462,25 +466,27 @@ def log_experiment_results_to_wandb(
     debug_artifact = None
     if config.debug_mode:
         debug_artifact = wandb.Artifact(
-            name=f"debug_files_{config.language}",
+            name=f"debug_files_{config.language}_{timestamp}",
             type="debug-files", 
             description=f"Debug and intermediate files from {config.language} processing",
             metadata={
                 "language": config.language,
                 "debug_mode": True,
                 "iterations": config.max_iterations,
+                "timestamp": timestamp,
             }
         )
     
     # 3. Summary and analysis artifact
     summary_artifact = wandb.Artifact(
-        name=f"analysis_{config.language}",
+        name=f"analysis_{config.language}_{timestamp}",
         type="analysis",
         description=f"Summary reports and CSV analysis for {config.language} experiment",
         metadata={
             "language": config.language,
             "total_files": len(results),
             "success_rate": success_percentage,
+            "timestamp": timestamp,
         }
     )
     
@@ -508,14 +514,14 @@ def log_experiment_results_to_wandb(
     
     # Log all artifacts
     wandb.log_artifact(code_artifact)
-    print(f"✅ Generated code uploaded to wandb artifact: generated_code_{config.language}")
+    print(f"✅ Generated code uploaded to wandb artifact: generated_code_{config.language}_{timestamp}")
     
     if debug_artifact and config.debug_mode:
         wandb.log_artifact(debug_artifact)
-        print(f"✅ Debug files uploaded to wandb artifact: debug_files_{config.language}")
+        print(f"✅ Debug files uploaded to wandb artifact: debug_files_{config.language}_{timestamp}")
     
     wandb.log_artifact(summary_artifact) 
-    print(f"✅ Analysis files uploaded to wandb artifact: analysis_{config.language}")
+    print(f"✅ Analysis files uploaded to wandb artifact: analysis_{config.language}_{timestamp}")
     
     # Store key files directly in wandb.summary for easy access
     if output_path.exists():

--- a/src/spec_to_code.py
+++ b/src/spec_to_code.py
@@ -421,7 +421,8 @@ def log_experiment_results_to_wandb(
     # Create comprehensive results table with file contents
     results_table = wandb.Table(columns=[
         "file_name", "subfolder", "success", "output_file", "error_message",
-        "has_bypass", "file_path", "original_spec", "final_output", "debug_files"
+        "has_bypass", "file_path", "original_spec", "final_output", "debug_files",
+        "generate_prompt", "fix_prompts"
     ])
     
     for result in results:
@@ -484,7 +485,9 @@ def log_experiment_results_to_wandb(
             str(result.file),
             original_spec,
             final_output,
-            debug_files_text or "No debug files"
+            debug_files_text or "No debug files",
+            result.generate_prompt if hasattr(result, 'generate_prompt') and result.generate_prompt else "",
+            "\\n\\n---\\n\\n".join(result.fix_prompts) if hasattr(result, 'fix_prompts') and result.fix_prompts else ""
         )
     
     wandb.log({"detailed_results": results_table})


### PR DESCRIPTION
I fed Claude the google doc requirements, so I can't vouch for the code quality

Now W&B saves the current commit, the argparse arguments, etc. In particular, you can now view the debug files under `runs.summary["detailed_results"]`. 

See https://wandb.ai/vericoding/vericoding-testing/runs/pn2ejy4c/overview and https://wandb.ai/vericoding/vericoding-testing/runs/pn2ejy4c/workspace?nw=nwusertheodoreehrenborg

I ran with:
```
uv run src/spec_to_code.py verus verus/src/verus_specs/benches_no_bodies_20250809_091334/artifacts/dafnybench/630-dafny_tmp_tmpz2kokaiq_Solution/ --iterations 3 --debug --delete-after-upload
```