### PR TITLE
Symlink AGENTS.md to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
This PR creates a symlink so that `AGENTS.md` points to `CLAUDE.md` (or vice versa, when only one exists).

Closes #83.