### PR TITLE
Give better names to tests

### DIFF
--- a/.github/workflows/test-rust-to-yaml.yml
+++ b/.github/workflows/test-rust-to-yaml.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-rust-to-yaml:
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/test-verus-validation.yml
+++ b/.github/workflows/test-verus-validation.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  verus-test-data-syntax:
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
I'd like to turn on the setting where a branch must be up to date before it can be merged (see https://github.com/Beneficial-AI-Foundation/vericoding/pull/92#issuecomment-3223909175). To do this, Github says there must be a required status check. So I think these two tests (the edited yaml files) are good candidates for a required check because they're not flaky. But it turns out (https://stackoverflow.com/questions/68554735/github-action-status-check-missing-from-the-list-of-checks-in-protected-branch-s) that they need unique names in order to be used as status checks
