### PR TITLE
feat(lean): MCP-assisted harness with GPT/Claude support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,13 @@ dependencies = [
     "pandas>=2.3.1",
     "dataclasses-json>=0.6.7", # JSON serialization for dataclasses
     "tqdm>=4.67.1",
+    "mcp>=1.13.1",
+    "openai>=1.40.0",
 ]
 
 [project.optional-dependencies]
-openai = ["openai>=1.0.0"]
-all = ["openai>=1.0.0"]
+openai = ["openai>=1.40.0"]
+all = ["openai>=1.40.0"]
 test = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",

--- a/src/vericoding/core/prompts.py
+++ b/src/vericoding/core/prompts.py
@@ -41,8 +41,22 @@ class PromptLoader:
         if Path(self.prompts_file).exists():
             with Path(self.prompts_file).open() as f:
                 self.prompts = yaml.safe_load(f)
-        else:
-            raise FileNotFoundError(f"Prompts file not found: {self.prompts_file}")
+            return
+
+        # Lean prompts sometimes live under the repository's `lean/` folder.
+        # Fall back to that location to make the Lean harness work out-of-the-box.
+        if self.language == "lean":
+            repo_root = Path(__file__).parent.parent.parent.parent
+            alt_path = repo_root / "lean" / self.prompts_file
+            if alt_path.exists():
+                with alt_path.open() as f:
+                    self.prompts = yaml.safe_load(f)
+                return
+
+        # If still not found, raise a clear error
+        raise FileNotFoundError(
+            f"Prompts file not found for language '{self.language}': {self.prompts_file}"
+        )
 
     def format_prompt(self, prompt_name: str, **kwargs: Any) -> str:
         """Format a prompt with the given parameters."""

--- a/src/vericoding/lean/mcp_client.py
+++ b/src/vericoding/lean/mcp_client.py
@@ -1,0 +1,132 @@
+"""
+Lean MCP client wrapper.
+
+This module provides a light, best-effort interface to the `lean-lsp-mcp`
+server via the Python `mcp` client library. It is intentionally resilient:
+if the server or tools are unavailable, functions return empty strings
+instead of raising, so the harness can fall back to plain `lean` verification.
+
+Notes:
+- Requires the `mcp` package and the `lean-lsp-mcp` server to be installed.
+- We invoke the server using `uvx lean-lsp-mcp` to match project tooling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import anyio
+
+try:
+    # Optional dependency; code must degrade gracefully if absent
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+    MCP_AVAILABLE = True
+except Exception:  # pragma: no cover - import guard
+    MCP_AVAILABLE = False
+
+
+DEFAULT_SERVER_CMD = "uvx"
+DEFAULT_SERVER_ARGS = ["lean-lsp-mcp"]
+
+
+@dataclass
+class LeanMCPContext:
+    diagnostics: str = ""
+    term_goals: List[str] = None  # one per sorry line (best-effort)
+    hovers: List[str] = None      # optional hovers for nearby symbols
+
+    def render(self, max_len: int = 4000) -> str:
+        parts: List[str] = []
+        if self.diagnostics:
+            parts.append("[Diagnostics]\n" + self.diagnostics.strip())
+        if self.term_goals:
+            tg = "\n\n".join(x.strip() for x in self.term_goals if x.strip())
+            if tg:
+                parts.append("[Term Goals]\n" + tg)
+        if self.hovers:
+            hv = "\n\n".join(x.strip() for x in self.hovers if x.strip())
+            if hv:
+                parts.append("[Hover]\n" + hv)
+        text = "\n\n".join(parts).strip()
+        if len(text) > max_len:
+            return text[: max_len - 200] + "\n\n…(truncated)…"
+        return text
+
+
+async def _with_session(workdir: Path, fn):
+    """Start a stdio MCP session and run fn(session)."""
+    server = StdioServerParameters(command=DEFAULT_SERVER_CMD, args=DEFAULT_SERVER_ARGS, cwd=str(workdir))
+    async with stdio_client(server) as (read_stream, write_stream):
+        session = ClientSession(read_stream, write_stream)
+        await session.initialize()
+        return await fn(session)
+
+
+def _collect_sorry_lines(code: str, limit: int = 5) -> List[int]:
+    lines: List[int] = []
+    for i, line in enumerate(code.splitlines(), start=1):
+        if "sorry" in line:
+            lines.append(i)
+            if len(lines) >= limit:
+                break
+    return lines
+
+
+def call_tool(workdir: Path, name: str, arguments: Optional[Dict[str, Any]] = None) -> str:
+    """Call an MCP tool by name and return concatenated text contents.
+
+    Returns empty string on any failure.
+    """
+    if not MCP_AVAILABLE:
+        return ""
+
+    async def _run(session: ClientSession) -> str:
+        try:
+            result = await session.call_tool(name, arguments or {})
+            texts: List[str] = []
+            for item in result.content or []:
+                # TextContent has attribute 'text'
+                text = getattr(item, "text", None)
+                if text:
+                    texts.append(text)
+            return "\n".join(texts).strip()
+        except Exception:
+            return ""
+
+    try:
+        return anyio.run(_with_session, workdir, _run)
+    except Exception:
+        return ""
+
+
+def collect_context(workdir: Path, file_path: Path, current_code: str) -> LeanMCPContext:
+    """Best-effort harvest of diagnostics, term goals near `sorry`, and a few hovers."""
+    ctx = LeanMCPContext(diagnostics="", term_goals=[], hovers=[])
+    if not MCP_AVAILABLE:
+        return ctx
+
+    # Diagnostics for the full file
+    diag = call_tool(workdir, "lean_diagnostic_messages", {"file_path": str(file_path)})
+    ctx.diagnostics = diag or ""
+
+    # Term goals at a few 'sorry' lines
+    for ln in _collect_sorry_lines(current_code, limit=5):
+        goal = call_tool(workdir, "lean_term_goal", {"file_path": str(file_path), "line": ln})
+        if goal:
+            ctx.term_goals.append(f"line {ln}:\n{goal}")
+
+    # Simple hover info for the first few definitions (greedy heuristic)
+    for i, line in enumerate(current_code.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("def ") or stripped.startswith("theorem ") or stripped.startswith("lemma "):
+            hv = call_tool(workdir, "lean_hover_info", {"file_path": str(file_path), "line": i})
+            if hv:
+                ctx.hovers.append(f"line {i}:\n{hv}")
+            if len(ctx.hovers) >= 3:
+                break
+
+    return ctx
+

--- a/src/vericoding/lean/prompts-lean.yaml
+++ b/src/vericoding/lean/prompts-lean.yaml
@@ -1,0 +1,95 @@
+generate_code: |
+  The task is to generate a Lean file that is verified from an incomplete Lean file that contains the keyword "sorry" in place of desired code and proof blocks.
+
+  INPUT: a Lean file of the form
+         def def_type_1 := sorry
+         ...
+         def def_type_n := sorry
+         theorem thm_type_1 := sorry
+         ...
+         theorem thm_type_n := sorry
+    WHERE:
+    - where each def_type_i is of the form
+
+    name {{implicit_args}} (hypotheses) (arguments) : result
+
+    where "sorry" represents a missing implementation for a desired function.
+
+    - each theorem represents a property about one or more of the def_type_i. The theorem thype thm_type_i is of the form
+    {{implicit_arg1 : Type1}}
+    (explicit_arg2 : Type2)
+    (hypothesis : Prop)
+    : Conclusion
+
+    where "Conclusion" is a formula or conjunction of formulas representing the desired properties for some of the missing implementations in def def_type_1, ..., def def_type_n
+
+  OUTPUT: Return ONLY the complete Lean code file, wrapped in a ```lean code block. Do not include any explanations, reasoning, or markdown outside the code block.
+
+  The output should be a verified Lean file of the form:
+        def def_type_1 := implementation_1
+        ...
+        def def_type_n := implementation_n
+        theorem thm_type_1 := proof_1
+        ...
+        theorem thm_type_n := proof_n
+
+  CRITICAL RULES:
+  - do not change any of def_type_i or thm_type_i
+  - do not use sorry in the output file
+  - the input file may contain additional definitions (without "sorry") that you can use in implementations if needed.
+  - you can add helper definitions, theorems, and lemmas as needed, but the initial definitions and theorems must remain unchanged.
+  Moreover, for any new definition, lemma or theorem you add, add a comment of the form -- LLM HELPER on the line just before it.
+  - Return ONLY the Lean code, no explanations or markdown
+
+  LEAN SPECIFICATION WITH EMPTY DEFINITIONS AND PROOF BODIES:
+  {code}
+
+fix_verification: |
+  The task is to review definitions and theorems in a Lean file that do not verify due to missing or invalid implementations or proofs.
+  INPUT: a Lean file that contains some definitions and theorems that don't verify due to missing or invalid implementations or proofs.
+  The file contains:
+  - some atoms (def, lemma, theorem, ...) that have the comment -- LLM HELPER before them. These atoms you can change and remove at will.
+
+  For all the other atoms (that do not have the comment -- LLM HELPER) you are allowed to change the definition or proof body, but you are not allowed to change the name, type, or signature of the atom.
+
+  More precisely, these atoms will be of the form:
+  def def_type_1 := implementation_1
+  ...
+  def def_type_n := implementation_n
+  theorem thm_type_1 := proof_1
+  ...
+  theorem thm_type_n := proof_n
+
+  and you are allowed to change the implementation_i and proof_i, but you are not allowed to change def_type_i or thm_type_i. So the output file should contain:
+
+  def def_type_1 := implementation_upd_1
+  ...
+  def def_type_n := implementation_upd_n
+  theorem thm_type_1 := proof_upd_1
+  ...
+  theorem thm_type_n := proof_upd_n
+  where implementation_upd_i and proof_upd_i are the updated implementations and proofs that should verify.
+
+  POSITIVE CRITICAL RULES:
+  - you can change the implementation of def_type_i and proof of thm_type_i to fix the verification errors
+  - you can add helper definitions, theorems, and lemmas as needed, but the initial definitions and theorems must remain unchanged.
+  Moreover, for any new definition, lemma or theorem you add, add a comment of the form -- LLM HELPER on the line just before it.
+
+  NEGATIVE CRITICAL RULES:
+  - you should not add trivial annotations
+  - you should not add null checks on non-nullable types
+  - do not use sorry in the output file
+  - output valid Lean code
+  - Return ONLY the Lean code, no explanations or markdown
+
+  OUTPUT: Return ONLY the complete Lean code file, wrapped in a ```lean code block. Do not include any explanations, reasoning, or markdown outside the code block.
+
+  ERROR DETAILS from Lean verification of the given code:
+  {errorDetails}
+
+  Additional context from Lean MCP tools (diagnostics/goals/hover). You may assume these are authoritative details from the Lean LSP. If present, use this information to directly fix the code without adding commentary:
+  {mcpContext}
+
+  Code Below:
+  {code}
+


### PR DESCRIPTION
This PR improves the Lean harness to run experiments on GPT and Claude with MCP tooling.\n\nHighlights:\n- Integrate Python MCP client to query lean-lsp-mcp (diagnostics, term goals, hover).\n- Enrich fix prompts with MCP context (spam diagnostics/goals/hover).\n- Add Lean prompts YAML under src for unified harness.\n- Prompt loader fallback to repo-level lean/prompts-lean.yaml.\n- Add OpenAI + MCP deps; maintain DeepSeek & Anthropic providers.\n- No breaking changes for Dafny/Verus.\n\nNotes:\n- Uses  and  Python lib; works best when run via Provide a command or script to invoke with `uv run <command>` or `uv run <script>.py`.

The following commands are available in the environment:

- distro
- dotenv
- f2py
- httpx
- jsonschema
- mcp
- normalizer
- numpy-config
- openai
- python
- python3
- python3.12
- tqdm
- uvicorn
- vericode-lean
- wandb
- wb

See `uv run --help` for more information..\n- OpenAI provider requires OPENAI_API_KEY env var; Claude requires ANTHROPIC_API_KEY.\n