### PR TITLE
Set default W&B project to 'vericoding'

### DIFF
--- a/src/vericoding/lean/tracker.py
+++ b/src/vericoding/lean/tracker.py
@@ -49,13 +49,15 @@ class ExperimentResult:
 class LeanExperimentTracker:
     """Track Lean verification experiments with WANDB."""
     
-    def __init__(self, project_name: str = "vericoding-lean"):
+    def __init__(self, project_name: str | None = None):
         """Initialize the experiment tracker.
         
         Args:
-            project_name: WANDB project name
+            project_name: WANDB project name. If None, uses
+                `WANDB_PROJECT` env var or falls back to "vericoding".
         """
-        self.project_name = project_name
+        # Prefer explicit arg, then env, then repo default
+        self.project_name = project_name or os.getenv("WANDB_PROJECT", "vericoding")
         self.results: List[ExperimentResult] = []
         self.wandb_enabled = os.getenv("WANDB_API_KEY") is not None
         self.run = None


### PR DESCRIPTION
This PR standardizes the default Weights & Biases project to `vericoding` across the codebase.

Changes
- Lean tracker: defaults to `os.getenv("WANDB_PROJECT", "vericoding")` instead of hardcoded value.
- Verified existing call sites already use `project=os.getenv("WANDB_PROJECT", "vericoding")`.
- `.env` and `wandb/` are already in `.gitignore` (no repo secrets).

Notes
- Local CLI `wandb status` may still show a different default; our code respects `WANDB_PROJECT` and falls back to `vericoding`.
- To align CLI default: `wandb settings --set project=vericoding`.
