### PR TITLE
lean: split out Multiset/Matrix changes from #172

### DIFF
--- a/benchmarks/lean/Benchmarks/MatrixDef.lean
+++ b/benchmarks/lean/Benchmarks/MatrixDef.lean
@@ -1,0 +1,14 @@
+/-!
+# Benchmarks.MatrixDef
+
+Lightweight matrix definitions used by older numpy specs. This mirrors
+the minimal helper introduced upstream (see commit 5ea12041a) so that
+files importing `Benchmarks.MatrixDef` continue to compile.
+-/
+
+/-- Simple Matrix type as a function from indices to values. -/
+def Matrix (m n : Nat) (α : Type) := Fin m → Fin n → α
+
+/-- Simple 3D array type. -/
+def Array3 (l m n : Nat) (α : Type) := Fin l → Fin m → Fin n → α
+

--- a/benchmarks/lean/dafnybench/DutchFlag.lean
+++ b/benchmarks/lean/dafnybench/DutchFlag.lean
@@ -8,7 +8,7 @@ which partitions an array of colors (Red, White, Blue) such that
 all reds come before whites, and all whites come before blues.
 -/
 
-import NumpySpec.DafnyBenchmarks.Multiset
+import dafnybench.Multiset
 
 namespace DafnyBenchmarks
 

--- a/benchmarks/lean/dafnybench/InsertionSortMultiset.lean
+++ b/benchmarks/lean/dafnybench/InsertionSortMultiset.lean
@@ -7,7 +7,7 @@ This module contains specifications for binary search and insertion sort
 where correctness is specified using multisets.
 -/
 
-import NumpySpec.DafnyBenchmarks.Multiset
+import dafnybench.Multiset
 
 namespace DafnyBenchmarks
 

--- a/benchmarks/lean/dafnybench/InsertionSortSeq.lean
+++ b/benchmarks/lean/dafnybench/InsertionSortSeq.lean
@@ -7,7 +7,7 @@ This module contains specifications for checking if a sequence is sorted
 and for insertion sort algorithm.
 -/
 
-import NumpySpec.DafnyBenchmarks.Multiset
+import dafnybench.Multiset
 
 namespace DafnyBenchmarks
 

--- a/benchmarks/lean/dafnybench/Multiset.lean
+++ b/benchmarks/lean/dafnybench/Multiset.lean
@@ -8,7 +8,6 @@ without requiring Mathlib.
 In a real implementation, this would be replaced with Mathlib's Multiset.
 -/
 
-namespace NumpySpec.DafnyBenchmarks
 
 /-- A multiset (bag) is a collection where elements can appear multiple times -/
 structure Multiset (α : Type) where
@@ -19,22 +18,24 @@ structure Multiset (α : Type) where
 namespace Multiset
 
 /-- The empty multiset -/
-def empty {α : Type} : Multiset α := ⟨[]⟩
+def empty {α : Type} : Multiset α := sorry
 
 /-- Convert a list to a multiset -/
-def ofList {α : Type} (l : List α) : Multiset α := ⟨l⟩
+def ofList {α : Type} (l : List α) : Multiset α := sorry
 
 /-- Convert an array to a multiset -/
-def ofArray {α : Type} (a : Array α) : Multiset α := ⟨a.toList⟩
+def ofArray {α : Type} (a : Array α) : Multiset α := sorry
 
-/-- Check if two multisets are equal (same elements with same multiplicities) -/
-def eq {α : Type} [DecidableEq α] (m1 m2 : Multiset α) : Prop := sorry
+/-- Check if two multisets are equal (same elements with same multiplicities).
+    Implemented by comparing element counts induced by the underlying lists. -/
+def eq {α : Type} [DecidableEq α] (m1 m2 : Multiset α) : Prop :=
+  ∀ x : α, (m1.data.count x) = (m2.data.count x)
 
 /-- Count occurrences of an element in a multiset -/
 def count {α : Type} [DecidableEq α] (m : Multiset α) (x : α) : Nat := sorry
 
 /-- Check if an element is in the multiset -/
-def mem {α : Type} [DecidableEq α] (x : α) (m : Multiset α) : Prop := sorry
+def mem {α : Type} [DecidableEq α] (x : α) (m : Multiset α) : Prop := x ∈ m.data
 
 /-- Size of a multiset -/
 def size {α : Type} (m : Multiset α) : Nat := sorry
@@ -54,9 +55,9 @@ def insert {α : Type} (x : α) (m : Multiset α) : Multiset α := sorry
 /-- Check if multiset is empty -/
 def isEmpty {α : Type} (m : Multiset α) : Bool := sorry
 
-/-- Notation for membership -/
-instance {α : Type} [DecidableEq α] : Membership α (Multiset α) where
-  mem x m := mem x m
+-- /-- Notation for membership -/
+-- instance {α : Type} [DecidableEq α] : Membership α (Multiset α) where
+--   mem x m := mem x m
 
 /-- Decidable equality for multisets -/
 instance {α : Type} [DecidableEq α] : DecidableEq (Multiset α) := sorry
@@ -67,4 +68,18 @@ instance {α : Type} [DecidableEq α] : BEq (Multiset α) where
 
 end Multiset
 
-end NumpySpec.DafnyBenchmarks
+/-! Convenience conversions used by DafnyBench specs -/
+
+namespace List
+
+/-- Convert a list to a multiset. Stubbed for specs. -/
+def toMultiset {α : Type} (l : List α) : Multiset α := sorry
+
+end List
+
+namespace Array
+
+/-- Convert an array to a multiset. Stubbed for specs. -/
+def toMultiset {α : Type} (a : Array α) : Multiset α := sorry
+
+end Array

--- a/benchmarks/lean/dafnybench/QuickSelect.lean
+++ b/benchmarks/lean/dafnybench/QuickSelect.lean
@@ -7,7 +7,7 @@ This module contains specifications for partitioning and QuickSelect algorithm
 using multisets to find the k-th smallest element.
 -/
 
-import NumpySpec.DafnyBenchmarks.Multiset
+import dafnybench.Multiset
 
 namespace DafnyBenchmarks
 

--- a/benchmarks/lean/dafnybench/SelectionSortMultiset.lean
+++ b/benchmarks/lean/dafnybench/SelectionSortMultiset.lean
@@ -7,7 +7,7 @@ This module contains specifications for finding minimum in a multiset
 and selection sort where correctness is specified using multisets.
 -/
 
-import NumpySpec.DafnyBenchmarks.Multiset
+import dafnybench.Multiset
 
 namespace DafnyBenchmarks
 


### PR DESCRIPTION
This PR extracts the .lean-only changes related to Multiset and Matrix from #172, so they can be reviewed/merged independently.\n\nIncluded files:\n- benchmarks/lean/Benchmarks/MatrixDef.lean (new minimal Matrix/Array3 definitions)\n- benchmarks/lean/dafnybench/Multiset.lean (Multiset stub + conversions)\n- Fix imports to use  in the following:\n  - DutchFlag.lean\n  - InsertionSortMultiset.lean\n  - InsertionSortSeq.lean\n  - QuickSelect.lean\n  - SelectionSortMultiset.lean\n\nNo changes to Python or lake config are included. These changes are intended to be self-contained and unblock specs that depend on a basic Multiset and MatrixDef.