### PR TITLE
Count tokens correctly

### DIFF
--- a/src/vericoding/core/llm_providers.py
+++ b/src/vericoding/core/llm_providers.py
@@ -433,8 +433,6 @@ def call_llm(provider: LLMProvider, config: ProcessingConfig, prompt: str, wandb
             "llm/calls": 1,
             "llm/latency_ms": latency_ms,
             "llm/model": model_name,
-            "llm/input_tokens": llm_response.input_tokens,
-            "llm/output_tokens": llm_response.output_tokens,
         })
     
     return llm_response.text


### PR DESCRIPTION
Current token counting is inaccurate, e.g. https://wandb.ai/vericoding/vericoding/runs/2edmhzho/overview says there were only ~3k input tokens, after processing 70 files. I think this is because that statistic gets overwritten on W&B for each file, not summed

Claude wrote this fix, but I've checked that token counts go up if I increase --limit and/or --iterations

I want this feature so I can estimate how much the weekend runs will cost