### PR TITLE
Improve vericoder: output paths, LLM args, and prompt strenghtning

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: leanprover/lean-action@v1
         with:
-          build-args: Benchmarks
+          build-args: BenchmarksCheckedInCI

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -58,3 +58,15 @@ lean_lib Benchmarks where
     .andSubmodules `verina,
   ]
   srcDir := "benchmarks/lean"
+
+
+lean_lib BenchmarksCheckedInCI where
+  globs := #[
+    .submodules `apps.files,
+    .submodules `dafnybench.poor.unformatted,
+    .submodules `humaneval.files,
+    .submodules `numpy_simple.poor.unformatted,
+    .submodules `numpy_triple.files,
+    .submodules `verina.files,
+  ]
+  srcDir := "benchmarks/lean"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -33,11 +33,12 @@ particularly Dafny benchmarks and NumPy specifications.
 -- lean_lib DafnyBenchSpecs where
 --   globs := #[.andSubmodules `DafnyBenchSpecs]
 
--- spec_to_code.py puts files here
+-- vericoder.py puts files here
 lean_lib Generated where
   globs := #[.andSubmodules `Generated]
   srcDir := "lean"
 
+-- Original benchmark files + all vericoder generated files
 lean_lib Benchmarks where
   globs := #[
     .submodules `apps.files,
@@ -46,5 +47,14 @@ lean_lib Benchmarks where
     .submodules `numpy_simple.poor.unformatted,
     .submodules `numpy_triple.files,
     .submodules `verina.files,
+    -- Include all subdirectories (including vericoder_* dirs)
+    .andSubmodules `apps,
+    .andSubmodules `bignum,
+    .andSubmodules `dafnybench,
+    .andSubmodules `humaneval,
+    .andSubmodules `humaneval_clever,
+    .andSubmodules `numpy_simple,
+    .andSubmodules `numpy_triple,
+    .andSubmodules `verina,
   ]
   srcDir := "benchmarks/lean"

--- a/src/dafny/prompts.yaml
+++ b/src/dafny/prompts.yaml
@@ -1,4 +1,6 @@
 generate_code: |
+  CRITICAL: Respond with ONLY a JSON array. No explanations, reasoning, or markdown. Start with [ and end with ].
+  
   The task is to generate implementations for `<vc-code>` and `<vc-helpers>` sections in a Dafny file.
   
   TURN 1 of {max_iterations}: This is the initial code generation phase. You have {max_iterations} total turns to get this right, so you can iterate and improve.
@@ -7,26 +9,52 @@ generate_code: |
   
   OUTPUT: Return a JSON array with EXACTLY {placeholder_count} replacements (one for each placeholder section in the file), in order from top to bottom:
   ```json
-  ["{{\n  prefixes := [];\n  // implementation here\n}}", "{{\n  // helper code\n}}", "{{\n  // second implementation\n}}"]
+  ["function min(a: int, b: int): int {{ if a < b then a else b }}", "{{\n  result := ComputeResult(n, pos);\n}}"]
   ```
+  
+  SECTION-SPECIFIC RULES:
+  
+  **For `<vc-helpers>` sections:**
+  - Provide COMPLETE helper function/lemma definitions ONLY
+  - Each helper should be a standalone function/predicate/lemma with proper signature
+  - Example: `function min(a: int, b: int): int {{ if a < b then a else b }}`
+  - Example: `predicate IsValid(x: int) {{ x >= 0 }}`
+  - Example: `lemma HelperLemma(x: int) ensures x + 0 == x {{ }}`
+  - DO NOT include method body code, variable assignments, or code fragments
+  - DO NOT include opening/closing braces unless they're part of the function body
+  
+  **For `<vc-code>` sections:**
+  - Provide method body implementation code ONLY
+  - Always include opening/closing braces: `{{\n  \n}}`
+  - Example: `{{\n  result := min(a, b) + 1;\n}}`
+  - This is where you call helper functions and implement the main logic
+  - Include variable declarations, assignments, and control flow
   
   CRITICAL RULES:
   - The ORIGINAL file contains EXACTLY {placeholder_count} placeholder sections - your JSON array must have EXACTLY {placeholder_count} elements
   - Provide exactly one replacement for each placeholder section in the file, in the exact order they appear (top to bottom)
-  - Each replacement should be the exact code that will replace everything between the tags (`<vc-code>` or `<vc-helpers>`)
-  - For `<vc-code>` sections: Provide main implementation code
-  - For `<vc-helpers>` sections: Provide helper functions, lemmas, or utility code
-  - Include opening/closing braces if they were in the original placeholder content
-  - AVOID verification bypasses: `{{:axiom}}`, `assume` statements, or other verification shortcuts
+  - Each replacement should be the exact code that will replace everything between the tags
+  - NEVER use verification bypasses: `{{:axiom}}`, `assume` statements, or other verification shortcuts
+  - Implement actual proofs and logic instead of bypassing verification
   - Use valid Dafny syntax for all implementations
   - Satisfy all `requires` and `ensures` clauses from the method/function specifications
   - Do not add trivial or unnecessary annotations
   - Return ONLY a valid JSON array, no explanations or markdown
+  - DO NOT include any reasoning, explanations, or commentary
+  - DO NOT use markdown code blocks around the JSON
+  - Your response must start with [ and end with ]
+  - Each JSON string must be properly escaped with double quotes
+  
+  CRITICAL: Your entire response must be ONLY the JSON array. Any text before or after the JSON will cause parsing failure.
+  
+  CRITICAL: Do NOT use `assume {{:axiom}}`, `assume`, or any verification bypasses. Implement real logic!
   
   DAFNY FILE WITH PLACEHOLDER SECTIONS:
   {code}
 
 fix_verification: |
+  CRITICAL: Respond with ONLY a JSON array. No explanations, reasoning, or markdown. Start with [ and end with ].
+  
   The task is to fix implementations in `<vc-code>` and `<vc-helpers>` sections that failed verification.
   
   TURN {iteration} of {max_iterations}: You are making progress and have multiple turns to iterate and improve your implementation.
@@ -35,23 +63,48 @@ fix_verification: |
   
   OUTPUT: Return a JSON array with EXACTLY {placeholder_count} fixed replacements (one for each placeholder section in the ORIGINAL file), in order from top to bottom:
   ```json
-  ["{{\n  prefixes := [];\n  // fixed implementation here\n}}", "{{\n  // fixed helper code\n}}", "{{\n  // second fixed implementation\n}}"]
+  ["function min(a: int, b: int): int {{ if a < b then a else b }}", "{{\n  result := min(a, b) + 1;\n}}"]
   ```
+  
+  SECTION-SPECIFIC RULES:
+  
+  **For `<vc-helpers>` sections:**
+  - Provide COMPLETE helper function/lemma definitions ONLY
+  - Each helper should be a standalone function/predicate/lemma with proper signature
+  - Example: `function min(a: int, b: int): int {{ if a < b then a else b }}`
+  - Example: `predicate IsValid(x: int) {{ x >= 0 }}`
+  - Example: `lemma HelperLemma(x: int) ensures x + 0 == x {{ }}`
+  - DO NOT include method body code, variable assignments, or code fragments
+  - DO NOT include opening/closing braces unless they're part of the function body
+  - Add comment `/* helper modified by LLM (iteration {iteration}): [brief description] */` before modified helpers
+  
+  **For `<vc-code>` sections:**
+  - Provide method body implementation code ONLY
+  - Always include opening/closing braces: `{{\n  \n}}`
+  - Example: `{{\n  result := min(a, b) + 1;\n}}`
+  - This is where you call helper functions and implement the main logic
+  - Include variable declarations, assignments, and control flow
+  - Add comment `/* code modified by LLM (iteration {iteration}): [brief description] */` at the start of method body
   
   CRITICAL RULES:
   - The ORIGINAL file contains EXACTLY {placeholder_count} placeholder sections - your JSON array must have EXACTLY {placeholder_count} elements
   - Provide exactly one replacement for each placeholder section in the file, in the exact order they appear (top to bottom)
-  - Each replacement should be the exact fixed code that will replace everything between the tags (`<vc-code>` or `<vc-helpers>`)
-  - For `<vc-code>` sections: Provide main implementation code
-  - For `<vc-helpers>` sections: Provide helper functions, lemmas, or utility code
-  - Include opening/closing braces if they were in the original placeholder content
+  - Each replacement should be the exact fixed code that will replace everything between the tags
   - PRIORITY: If the error is a compilation error (syntax, type, resolution errors), fix it first before addressing verification issues
-  - MINIMIZE verification bypasses: `{{:axiom}}`, `assume` statements, or other verification shortcuts
+  - NEVER use verification bypasses: `{{:axiom}}`, `assume` statements, or other verification shortcuts
+  - Implement actual proofs and logic instead of bypassing verification
   - Use valid Dafny syntax for all implementations
   - Satisfy all `requires` and `ensures` clauses from the method/function specifications
   - Do not add trivial or unnecessary annotations
-  - Add comment `/* code modified by LLM (iteration {iteration}): [brief description] */` before modified code
   - Return ONLY a valid JSON array, no explanations or markdown
+  - DO NOT include any reasoning, explanations, or commentary
+  - DO NOT use markdown code blocks around the JSON
+  - Your response must start with [ and end with ]
+  - Each JSON string must be properly escaped with double quotes
+  
+  CRITICAL: Your entire response must be ONLY the JSON array. Any text before or after the JSON will cause parsing failure.
+  
+  CRITICAL: Do NOT use `assume {{:axiom}}`, `assume`, or any verification bypasses. Implement real logic!
   
   ERROR DETAILS from Dafny verification:
   {errorDetails}

--- a/src/vericoding/core/config.py
+++ b/src/vericoding/core/config.py
@@ -59,11 +59,9 @@ class ProcessingConfig:
     output_dir: str
     summary_file: str
     debug_mode: bool
-    strict_spec_verification: bool
     max_workers: int
     api_rate_limit_delay: int
-    llm_provider: str
-    llm_model: str | None
+    llm: str
     max_directory_traversal_depth: int = 50
 
     # Static configuration loaded once

--- a/src/vericoding/core/llm_providers.py
+++ b/src/vericoding/core/llm_providers.py
@@ -435,8 +435,7 @@ def call_llm(provider: LLMProvider, config: ProcessingConfig, prompt: str, wandb
                 "llm/latency_ms": latency_ms,
                 "llm/model": model_name,
             })
-        except Exception:
-            # Silently ignore W&B logging errors to prevent processing failures
-            pass
+        except Exception as e:
+            print(f"There was a W&B error {e} in llm_providers.py")
     
     return llm_response.text

--- a/src/vericoding/processing/cheat_checker.py
+++ b/src/vericoding/processing/cheat_checker.py
@@ -51,6 +51,8 @@ def check_for_cheats(code: str, language: str) -> List[Tuple[str, str]]:
     elif language.lower() == "dafny":
         cheat_patterns = [
             (r'\{:axiom\}', "uses '{:axiom}' to bypass verification"),
+            (r'\bassume\b', "uses 'assume' to bypass verification"),
+            (r'assume\s*\{:axiom\}', "uses 'assume {:axiom}' to bypass verification"),
         ]
         
         # For Dafny, only check for cheats inside editable sections (vc-code, vc-helpers)

--- a/src/vericoding/processing/code_fixer.py
+++ b/src/vericoding/processing/code_fixer.py
@@ -72,8 +72,6 @@ def extract_code(config: ProcessingConfig, output: str) -> str:
 
 
 
-
-
 def apply_json_replacements(config: ProcessingConfig, original_code: str, llm_response: str) -> tuple[str, str | None]:
     """Apply JSON array of replacements to original code.
     

--- a/src/vericoding/utils/__init__.py
+++ b/src/vericoding/utils/__init__.py
@@ -12,7 +12,6 @@ from .io_utils import (
 from .reporting import (
     generate_csv_results,
     generate_summary,
-    generate_subfolder_analysis_csv,
 )
 
 __all__ = [
@@ -23,5 +22,4 @@ __all__ = [
     "save_iteration_code",
     "generate_csv_results",
     "generate_summary",
-    "generate_subfolder_analysis_csv",
 ]

--- a/src/vericoding/utils/reporting.py
+++ b/src/vericoding/utils/reporting.py
@@ -78,84 +78,16 @@ def generate_csv_results(config: ProcessingConfig, results: list) -> str:
     return str(csv_file)
 
 
-def generate_subfolder_analysis_csv(config: ProcessingConfig, results: list) -> str:
-    """Generate CSV file with subfolder success rate analysis."""
-    csv_file = Path(config.output_dir) / "subfolder_analysis.csv"
-
-    # Analyze results by subfolder
-    from collections import defaultdict
-
-    subfolder_stats = defaultdict(lambda: {"success": 0, "failed": 0, "total": 0})
-
-    for result in results:
-        # Extract subfolder from file path
-        file_path = Path(result.file)
-        if len(file_path.parts) > 1:
-            subfolder = file_path.parts[0]
-        else:
-            subfolder = "root"
-
-        subfolder_stats[subfolder]["total"] += 1
-        if result.success:
-            subfolder_stats[subfolder]["success"] += 1
-        else:
-            subfolder_stats[subfolder]["failed"] += 1
-
-    with csv_file.open("w", newline="") as csvfile:
-        writer = csv.writer(csvfile)
-        # Write header
-        writer.writerow(["subfolder", "successful", "failed", "total", "success_rate"])
-
-        # Write subfolder statistics sorted by name
-        for subfolder in sorted(subfolder_stats.keys()):
-            stats = subfolder_stats[subfolder]
-            success_rate = (
-                (stats["success"] / stats["total"] * 100) if stats["total"] > 0 else 0.0
-            )
-            writer.writerow(
-                [
-                    subfolder,
-                    stats["success"],
-                    stats["failed"],
-                    stats["total"],
-                    f"{success_rate:.1f}%",
-                ]
-            )
-
-    print(f"Subfolder analysis CSV saved to: {csv_file}")
-    return str(csv_file)
-
-
 def generate_summary(config: ProcessingConfig, results: list) -> str:
     """Generate a summary of the processing results."""
     successful = [r for r in results if r.success]
     failed = [r for r in results if not r.success]
 
-    # Analyze results by subfolder
-    from collections import defaultdict
-
-    subfolder_stats = defaultdict(lambda: {"success": 0, "failed": 0, "total": 0})
-
-    for result in results:
-        # Extract subfolder from file path
-        file_path = Path(result.file)
-        if len(file_path.parts) > 1:
-            subfolder = file_path.parts[0]
-        else:
-            subfolder = "root"
-
-        subfolder_stats[subfolder]["total"] += 1
-        if result.success:
-            subfolder_stats[subfolder]["success"] += 1
-        else:
-            subfolder_stats[subfolder]["failed"] += 1
-
     summary_lines = [
         f"=== {config.language_config.name.upper()} SPECIFICATION-TO-CODE PROCESSING SUMMARY (PARALLEL VERSION) ===",
         "",
         f"Language: {config.language_config.name}",
-        f"LLM Provider: {config.llm_provider}",
-        f"LLM Model: {config.llm_model or 'default'}",
+        f"LLM: {config.llm}",
         f"Test directory: {config.files_dir}",
         f"Output directory: {config.output_dir}",
         f"Max iterations: {config.max_iterations}",
@@ -169,25 +101,7 @@ def generate_summary(config: ProcessingConfig, results: list) -> str:
         f"Total failed: {len(failed)}",
         f"Success rate: {(len(successful) / len(results) * 100) if results else 0.0:.1f}%",
         "",
-        "=== SUCCESS RATE BY SUBFOLDER ===",
     ]
-
-    # Sort subfolders by name for consistent output
-    for subfolder in sorted(subfolder_stats.keys()):
-        stats = subfolder_stats[subfolder]
-        success_rate = (
-            (stats["success"] / stats["total"] * 100) if stats["total"] > 0 else 0.0
-        )
-        summary_lines.extend(
-            [
-                f"{subfolder}:",
-                f"  Successful: {stats['success']}",
-                f"  Failed: {stats['failed']}",
-                f"  Total: {stats['total']}",
-                f"  Success rate: {success_rate:.1f}%",
-                "",
-            ]
-        )
 
     summary_lines.extend(
         [

--- a/src/verus/prompts.yaml
+++ b/src/verus/prompts.yaml
@@ -1,4 +1,6 @@
 generate_code: |
+  CRITICAL: Respond with ONLY a JSON array. No explanations, reasoning, or markdown. Start with [ and end with ].
+  
   The task is to generate implementations for `<vc-code>` and `<vc-helpers>` sections in a Verus file.
   
   TURN 1 of {max_iterations}: This is the initial code generation phase. You have {max_iterations} total turns to get this right, so you can iterate and improve.
@@ -7,28 +9,54 @@ generate_code: |
   
   OUTPUT: Return a JSON array with EXACTLY {placeholder_count} replacements (one for each placeholder section in the file), in order from top to bottom:
   ```json
-  ["{{\n    let mut low = 0;\n    // implementation here\n}}", "{{\n    // helper code\n}}", "{{\n    // second implementation\n}}"]
+  ["fn min(a: int, b: int) -> int {{ if a < b {{ a }} else {{ b }} }}", "{{\n    let result = min(a, b);\n    result\n}}"]
   ```
+  
+  SECTION-SPECIFIC RULES:
+  
+  **For `<vc-helpers>` sections:**
+  - Provide COMPLETE helper function/lemma definitions ONLY
+  - Each helper should be a standalone function/predicate/lemma with proper signature
+  - Example: `fn min(a: int, b: int) -> int {{ if a < b {{ a }} else {{ b }} }}`
+  - Example: `spec fn is_valid(x: int) -> bool {{ x >= 0 }}`
+  - Example: `proof fn helper_lemma(x: int) ensures x + 0 == x {{ }}`
+  - DO NOT include method body code, variable assignments, or code fragments
+  - DO NOT include opening/closing braces unless they're part of the function body
+  
+  **For `<vc-code>` sections:**
+  - Provide method/function body implementation code ONLY
+  - Always include opening/closing braces: `{{\n \n}}`
+  - Example: `{{\n    let result = min(a, b);\n    result\n}}`
+  - This is where you call helper functions and implement the main logic
+  - Include variable declarations, assignments, and control flow
   
   CRITICAL RULES:
   - The ORIGINAL file contains EXACTLY {placeholder_count} placeholder sections - your JSON array must have EXACTLY {placeholder_count} elements
   - Provide exactly one replacement for each placeholder section in the file, in the exact order they appear (top to bottom)
-  - Each replacement should be the exact code that will replace everything between the tags (`<vc-code>` or `<vc-helpers>`)
-  - For `<vc-code>` sections: Provide main implementation code
-  - For `<vc-helpers>` sections: Provide helper functions, lemmas, or utility code
-  - Include opening/closing braces if they were in the original placeholder content
-  - AVOID verification bypasses: `assume` statements, `unimplemented!()`, or other verification shortcuts
+  - Each replacement should be the exact code that will replace everything between the tags
+  - NEVER use verification bypasses: `assume` statements, `unimplemented!()`, or other verification shortcuts
+  - Implement actual proofs and logic instead of bypassing verification
   - Use valid Verus/Rust syntax for all implementations
   - Use proper Verus syntax: `requires`, `ensures`, `invariant`, `decreases` (without parentheses)
   - Use Verus types like `nat`, `int`, `Vec<T>`, `Seq<T>`, etc.
   - Use `@` for sequence/vector indexing when needed (e.g., `v@[i]`)
   - Use proof blocks with `proof {{ ... }}` when necessary
   - Return ONLY a valid JSON array, no explanations or markdown
+  - DO NOT include any reasoning, explanations, or commentary
+  - DO NOT use markdown code blocks around the JSON
+  - Your response must start with [ and end with ]
+  - Each JSON string must be properly escaped with double quotes
+  
+  CRITICAL: Your entire response must be ONLY the JSON array. Any text before or after the JSON will cause parsing failure.
+  
+  CRITICAL: Do NOT use `assume`, `unimplemented!()`, or any verification bypasses. Implement real logic!
   
   VERUS FILE WITH PLACEHOLDER SECTIONS:
   {code}
 
 fix_verification: |
+  CRITICAL: Respond with ONLY a JSON array. No explanations, reasoning, or markdown. Start with [ and end with ].
+  
   The task is to fix implementations in `<vc-code>` and `<vc-helpers>` sections that failed verification.
   
   TURN {iteration} of {max_iterations}: You are making progress and have multiple turns to iterate and improve your implementation.
@@ -37,25 +65,50 @@ fix_verification: |
   
   OUTPUT: Return a JSON array with EXACTLY {placeholder_count} fixed replacements (one for each placeholder section in the ORIGINAL file), in order from top to bottom:
   ```json
-  ["{{\n    let mut low = 0;\n    // fixed implementation here\n}}", "{{\n    // fixed helper code\n}}", "{{\n    // second fixed implementation\n}}"]
+  ["fn min(a: int, b: int) -> int {{ if a < b {{ a }} else {{ b }} }}", "{{\n    let result = min(a, b);\n    result\n}}"]
   ```
+  
+  SECTION-SPECIFIC RULES:
+  
+  **For `<vc-helpers>` sections:**
+  - Provide COMPLETE helper function/lemma definitions ONLY
+  - Each helper should be a standalone function/predicate/lemma with proper signature
+  - Example: `fn min(a: int, b: int) -> int {{ if a < b {{ a }} else {{ b }} }}`
+  - Example: `spec fn is_valid(x: int) -> bool {{ x >= 0 }}`
+  - Example: `proof fn helper_lemma(x: int) ensures x + 0 == x {{ }}`
+  - DO NOT include method body code, variable assignments, or code fragments
+  - DO NOT include opening/closing braces unless they're part of the function body
+  - Add comment `/* helper modified by LLM (iteration {iteration}): [brief description] */` before modified helpers
+  
+  **For `<vc-code>` sections:**
+  - Provide method/function body implementation code ONLY
+  - Always include opening/closing braces: `{{\n  \n}}`
+  - Example: `{{\n    let result = min(a, b);\n    result\n}}`
+  - This is where you call helper functions and implement the main logic
+  - Include variable declarations, assignments, and control flow
+  - Add comment `/* code modified by LLM (iteration {iteration}): [brief description] */` at the start of method body
   
   CRITICAL RULES:
   - The ORIGINAL file contains EXACTLY {placeholder_count} placeholder sections - your JSON array must have EXACTLY {placeholder_count} elements
   - Provide exactly one replacement for each placeholder section in the file, in the exact order they appear (top to bottom)
-  - Each replacement should be the exact fixed code that will replace everything between the tags (`<vc-code>` or `<vc-helpers>`)
-  - For `<vc-code>` sections: Provide main implementation code
-  - For `<vc-helpers>` sections: Provide helper functions, lemmas, or utility code
-  - Include opening/closing braces if they were in the original placeholder content
+  - Each replacement should be the exact fixed code that will replace everything between the tags
   - PRIORITY: If the error is a compilation error (syntax, type, resolution errors), fix it first before addressing verification issues
   - Use proper Verus syntax: `requires`, `ensures`, `invariant`, `decreases` (without parentheses)
   - Use proof blocks with `proof {{ ... }}` for complex proofs
   - Use `assert()` statements within proof blocks for intermediate steps
   - Use Verus types and operators (`nat`, `int`, `Vec<T>`, `Seq<T>`, `@`, etc.)
-  - MINIMIZE verification bypasses: `assume` statements, `unimplemented!()`, or other verification shortcuts
+  - NEVER use verification bypasses: `assume` statements, `unimplemented!()`, or other verification shortcuts
+  - Implement actual proofs and logic instead of bypassing verification
   - Use `@` for sequence/vector indexing when needed (e.g., `v@[i]`)
-  - Add comment `/* code modified by LLM (iteration {iteration}): [brief description] */` before modified code
   - Return ONLY a valid JSON array, no explanations or markdown
+  - DO NOT include any reasoning, explanations, or commentary
+  - DO NOT use markdown code blocks around the JSON
+  - Your response must start with [ and end with ]
+  - Each JSON string must be properly escaped with double quotes
+  
+  CRITICAL: Your entire response must be ONLY the JSON array. Any text before or after the JSON will cause parsing failure.
+  
+  CRITICAL: Do NOT use `assume`, `unimplemented!()`, or any verification bypasses. Implement real logic!
   
   ERROR DETAILS from Verus verification:
   {errorDetails}

--- a/src/verus/prompts.yaml
+++ b/src/verus/prompts.yaml
@@ -38,6 +38,33 @@ generate_code: |
   - Implement actual proofs and logic instead of bypassing verification
   - Use valid Verus/Rust syntax for all implementations
   - Use proper Verus syntax: `requires`, `ensures`, `invariant`, `decreases` (without parentheses)
+  - IMPORTANT: Use each of `requires`, `ensures`, and `invariant` AT MOST ONCE per item
+    - List multiple conditions as comma-separated entries on separate lines
+    - Do NOT repeat `requires`/`ensures`/`invariant` keywords for additional lines
+    - Prefer commas at line ends in spec blocks; avoid semicolons
+  - While-loop header style (single invariant block):
+    
+    while CONDITION
+        invariant
+            INV1,
+            INV2,
+        decreases MEASURE
+    {{
+        // body
+    }}
+    
+  - Function spec header style (single requires/ensures blocks):
+    
+    fn f(..) -> T
+        requires
+            PRE1,
+            PRE2,
+        ensures
+            POST1,
+            POST2,
+    {{
+        // body
+    }}
   - Use Verus types like `nat`, `int`, `Vec<T>`, `Seq<T>`, etc.
   - Use `@` for sequence/vector indexing when needed (e.g., `v@[i]`)
   - Use proof blocks with `proof {{ ... }}` when necessary
@@ -94,6 +121,33 @@ fix_verification: |
   - Each replacement should be the exact fixed code that will replace everything between the tags
   - PRIORITY: If the error is a compilation error (syntax, type, resolution errors), fix it first before addressing verification issues
   - Use proper Verus syntax: `requires`, `ensures`, `invariant`, `decreases` (without parentheses)
+  - IMPORTANT: Use each of `requires`, `ensures`, and `invariant` AT MOST ONCE per item
+    - List multiple conditions as comma-separated entries on separate lines
+    - Do NOT repeat `requires`/`ensures`/`invariant` keywords for additional lines
+    - Prefer commas at line ends in spec blocks; avoid semicolons
+  - While-loop header style (single invariant block):
+    
+    while CONDITION
+        invariant
+            INV1,
+            INV2,
+        decreases MEASURE
+    {{
+        // body
+    }}
+    
+  - Function spec header style (single requires/ensures blocks):
+    
+    fn f(..) -> T
+        requires
+            PRE1,
+            PRE2,
+        ensures
+            POST1,
+            POST2,
+    {{
+        // body
+    }}
   - Use proof blocks with `proof {{ ... }}` for complex proofs
   - Use `assert()` statements within proof blocks for intermediate steps
   - Use Verus types and operators (`nat`, `int`, `Vec<T>`, `Seq<T>`, `@`, etc.)


### PR DESCRIPTION
- Change output to vericoder_<llm>_<date> format as sibling to input dir
- Replace --llm-provider/--llm-model with single --llm argument
- Strengthen prompts: NEVER use axioms, better JSON enforcement
- Remove deprecated --strict-specs option
- Fix retry logic and W&B error handling