### PR TITLE
Always run python tests

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -3,16 +3,8 @@ name: Python Code Quality
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - "vericoder.py"
-      - "vericoding/**/*.py"
-      - ".github/workflows/python-quality.yml"
   pull_request:
     branches: [ main, develop ]
-    paths:
-      - "vericoder.py"
-      - "vericoding/**/*.py"
-      - ".github/workflows/python-quality.yml"
   workflow_dispatch:
 
 jobs:
@@ -35,11 +27,9 @@ jobs:
     - name: Run Ruff linter
       uses: astral-sh/ruff-action@v3
       with:
-        src: "./vericoding ./vericoder.py"
         args: "check --output-format=github"
 
     - name: Check code formatting with Ruff
       uses: astral-sh/ruff-action@v3
       with:
-        src: "./vericoding ./vericoder.py"
         args: "format --check"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,24 +3,8 @@ name: Python Tests
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - "vericoder.py"
-      - "vericoding/**/*.py"
-      - "config/**/*.yaml"
-      - "tests/**/*.py"
-      - "pyproject.toml"
-      - "pytest.ini"
-      - ".github/workflows/python-tests.yml"
   pull_request:
     branches: [ main, develop ]
-    paths:
-      - "vericoder.py"
-      - "vericoding/**/*.py"
-      - "config/**/*.yaml"
-      - "tests/**/*.py"
-      - "pyproject.toml"
-      - "pytest.ini"
-      - ".github/workflows/python-tests.yml"
   workflow_dispatch:
 
 #permissions:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
         uv pip install -e ".[test]"
 
     - name: Run tests with coverage
-      run: source .venv/bin/activate && pytest tests/ -v --cov=vericoding --cov-report=xml --cov-report=html --cov-report=term-missing
+      run: source .venv/bin/activate && pytest src/tests/ -v --cov=vericoding --cov-report=xml --cov-report=html --cov-report=term-missing
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
We have python tests in CI, but they rarely run because they only activate when certain paths are changed. Hence they've been broken for a while

This PR does not fix the tests, but it always runs them so we can see they're broken

It should be fairly easy to fix the linter/formatter CI

I think some of the python tests might be out of date, so we could remove them