### PR TITLE
Add fallback to 'lake env lean' when 'lake build' fails

### DIFF
--- a/src/formatting/lean_check_compiling.py
+++ b/src/formatting/lean_check_compiling.py
@@ -19,6 +19,19 @@ def run_lake_build(file_path, cwd=Path.cwd()):
             text=True,
             cwd=cwd
         )
+
+        # If lake build fails, try fallback with lake env lean
+        if result.returncode != 0:
+            print(f"    Lake build failed, trying fallback with lake env lean...")
+            fallback_result = subprocess.run(
+                ['lake', 'env', 'lean', str(file_path)],
+                capture_output=True,
+                text=True,
+                cwd=cwd
+            )
+            if fallback_result.returncode == 0:
+                return fallback_result.returncode, fallback_result.stdout, fallback_result.stderr
+
         return result.returncode, result.stdout, result.stderr
     except Exception as e:
         return -1, "", str(e)


### PR DESCRIPTION
This change modifies the Lean verification logic to automatically fall back to building individual files with 'lake env lean' when 'lake build' fails.
