### PR TITLE
Set up local mathlib installation support

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,8 +1,7 @@
 import Lake
 open Lake DSL
 
-require mathlib from git
-  "https://github.com/leanprover-community/mathlib4" @ "v4.23.0-rc2"
+require mathlib from "../mathlib4"
 
 package Vericoding where
   version := v!"0.1.0"


### PR DESCRIPTION
This change allows using a locally-built mathlib4 installation instead of fetching from git. This is useful for:
- CI/CD pipelines with pre-built mathlib on S3
- Local development with custom mathlib modifications
- Faster builds by avoiding mathlib recompilation

## Setup Instructions

To use this configuration:

1. Clone mathlib4 as a sibling directory to vericoding3: ```bash cd ..  # Go to parent of vericoding3 git clone https://github.com/leanprover-community/mathlib4 cd mathlib4 git checkout v4.23.0-rc2  # Match the version we were using ```

2. Build mathlib (this will take significant time on first build): ```bash cd mathlib4 lake build ```

3. Optional but recommended: Use mathlib cache for faster setup: ```bash lake exe cache get ```

4. Return to vericoding3 and build: ```bash cd ../vericoding3 lake build ```

## For S3/CI Deployment

For S3-based deployment, the mathlib4 directory should be:
- Pre-built with the correct version (v4.23.0-rc2)
- Placed as a sibling directory to this repository
- Include the .lake/build directory with compiled oleans

The relative path ../mathlib4 assumes the following directory structure:
```
parent-directory/
├── vericoding3/
│   └── lakefile.lean (this file)
└── mathlib4/
    ├── .lake/
    │   └── build/  # Pre-compiled oleans
    └── Mathlib/
```