### PR TITLE
WandB run ID tracking

### DIFF
--- a/experiments/wandb_runs.json
+++ b/experiments/wandb_runs.json
@@ -3,7 +3,7 @@
         "claude-opus-4.1": {
             "numpy": "",
             "dafnybench": "",
-            "humaneval": "",
+            "humaneval": "i4iq17oc",
             "verina": "",
             "bignum": "",
             "verified-cogen": "",
@@ -12,7 +12,7 @@
         "claude-sonnet-4": {
             "numpy": "",
             "dafnybench": "",
-            "humaneval": "",
+            "humaneval": "wrhmb8ym",
             "verina": "naotuh11",
             "bignum": "",
             "verified-cogen": "",
@@ -21,7 +21,7 @@
         "deepseek-chat-v3.1": {
             "numpy": "",
             "dafnybench": "",
-            "humaneval": "",
+            "humaneval": "w2tfeaso",
             "verina": "",
             "bignum": "",
             "verified-cogen": "",
@@ -39,7 +39,7 @@
         "gemini-2.5-flash": {
             "numpy": "",
             "dafnybench": "",
-            "humaneval": "",
+            "humaneval": "a1b81hf8",
             "verina": "9jyu2isy",
             "bignum": "",
             "verified-cogen": "",
@@ -84,7 +84,7 @@
         "grok-code": {
             "numpy": "",
             "dafnybench": "",
-            "humaneval": "",
+            "humaneval": "3vei686v",
             "verina": "",
             "bignum": "",
             "verified-cogen": "",
@@ -185,94 +185,114 @@
     },
     "lean": {
         "claude-opus-4.1": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "tfro525h",
+            "dafnybench": "d8798wov",
             "humaneval": "rcdh7fah",
             "verina": "25h5d8zx",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "7115vfgo",
+            "fvapps": "",
+            "numpy-simple": "f6h92b1e",
+            "apps-test": "68zdp6ep"
         },
         "claude-sonnet-4": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "1euvcqak",
+            "dafnybench": "hnafwl5l",
             "humaneval": "x9mja2my",
             "verina": "7sd4l6u8",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "00z65het",
+            "fvapps": "",
+            "numpy-simple": "yivead3w",
+            "apps-test": "szs5pgde"
         },
         "deepseek-chat-v3.1": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "3g4hv1vw",
+            "dafnybench": "ig5bcvw3",
             "humaneval": "iukt3ogq",
             "verina": "7dyotrf6",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "8kb8247i",
+            "fvapps": "",
+            "numpy-simple": "yzvcv98k",
+            "apps-test": "g610pkct"
         },
         "gemini-2.5-pro": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "",
+            "dafnybench": "8j0e5eju",
             "humaneval": "d5lj4l8t",
             "verina": "ouoismef",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "o6z2wnic",
+            "fvapps": "",
+            "numpy-simple": "rq4yjwk9",
+            "apps-test": ""
         },
         "gemini-2.5-flash": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "9ataijh4",
+            "dafnybench": "vkebnz1m",
             "humaneval": "59k27lxw",
             "verina": "ffadfczz",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "zkecpthh",
+            "fvapps": "",
+            "numpy-simple": "j1ssp59n",
+            "apps-test": "1a9gxwjl"
         },
         "glm-4.5": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "lbagv5xp",
+            "dafnybench": "hmvkkns5",
             "humaneval": "rowtloiw",
             "verina": "nkh4sksd",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "9dfvyzld",
+            "fvapps": "",
+            "numpy-simple": "bjwqa1zf",
+            "apps-test": "tlw5nql0"
         },
         "gpt-5": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "",
+            "dafnybench": "hp66lx1o",
             "humaneval": "g37b80w3",
             "verina": "w4q1e8ki",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "laxcs1qy",
+            "fvapps": "",
+            "numpy-simple": "3jqxqo5s",
+            "apps-test": ""
         },
         "gpt-5-mini": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "7ojz3re0",
+            "dafnybench": "74biub63",
             "humaneval": "v9k0ly38",
             "verina": "uk362u5f",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "ry80t53g",
+            "fvapps": "",
+            "numpy-simple": "i0n2ixm0",
+            "apps-test": "f6e2ards"
         },
         "grok-4": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "",
+            "dafnybench": "0zwcka6j",
             "humaneval": "iyh9jlv8",
             "verina": "7tmvtcw2",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "798trm2f",
+            "fvapps": "",
+            "numpy-simple": "0ud8q1sv",
+            "apps-test": ""
         },
         "grok-code": {
-            "numpy": "",
-            "dafnybench": "",
+            "numpy-triple": "stoxofjg",
+            "dafnybench": "fatlfrpa",
             "humaneval": "tvajqu0j",
             "verina": "agafowd3",
             "bignum": "",
-            "verified-cogen": "",
-            "apps": ""
+            "verified-cogen": "gwgrvm3n",
+            "fvapps": "",
+            "numpy-simple": "b1dfxu59",
+            "apps-test": "05vojs3u"
         }
     }
 }

--- a/experiments/wandb_runs_vibe.json
+++ b/experiments/wandb_runs_vibe.json
@@ -168,7 +168,7 @@
             "numpy": "",
             "dafnybench": "",
             "humaneval": "",
-            "verina": "b26fnpxt",
+            "verina": "",
             "bignum": "",
             "verified-cogen": "",
             "apps": ""


### PR DESCRIPTION
This PR compiles the initial table of wandb run IDs corresponding to language-benchmark-llm combinations, scraped from overleaf. Please fill in the JSON as your experiments conclude and use these files as the source of truth for wandb run data.